### PR TITLE
S91.5 Pass correct fields data to find method

### DIFF
--- a/Model/Datasource/MongodbSource.php
+++ b/Model/Datasource/MongodbSource.php
@@ -1149,7 +1149,7 @@ class MongodbSource extends DboSource {
 			} else {
 				$return = $this->_db
 					->selectCollection($Model->table)
-					->find($conditions, $fields)
+					->find($conditions, array_combine($fields, array_fill(0, count($fields), 1)))
 					->sort($order)
 					->limit($limit)
 					->skip($offset);
@@ -1179,7 +1179,7 @@ class MongodbSource extends DboSource {
 				'remove' => !empty($remove),
 				'update' => $this->setMongoUpdateOperator($Model, $modify),
 				'new' => !empty($new),
-				'fields' => $fields,
+				'fields' => array_combine($fields, array_fill(0, count($fields), 1)),
 				'upsert' => !empty($upsert)
 			));
 			$return = $this->_db


### PR DESCRIPTION
ext-mongo is fine with receiving incorrect data and fixing it secretly. Instead of ['field', 'field'] it should receive ['field' => true, 'field' => true]. This commit fixes it for forward compatibility